### PR TITLE
Fix security vulnerability warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,9 @@
 		"webpack-cli": "^3.3.10",
 		"webpack-manifest-plugin": "v3.0.0-rc.0"
 	},
+	"resolutions": {
+		"serialize-javascript": "^2.1.1"
+	},
 	"lint-staged": {
 		"*.{js,json,html,css}": [
 			"prettier --write",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8072,10 +8072,10 @@ send@0.16.2:
     range-parser "~1.2.0"
     statuses "~1.4.0"
 
-serialize-javascript@^1.7.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
-  integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
+serialize-javascript@^1.7.0, serialize-javascript@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
+  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
 
 serve-index@1.9.1:
   version "1.9.1"


### PR DESCRIPTION
The vulnerability doesn't affect Node.js, but at least this will get rid
of the vulnerability warning :-)

See https://www.npmjs.com/advisories/1426