### PR TITLE
Remove the checkif there was a current sticker.

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -202,7 +202,8 @@ const sticker = {
 stickable.onmousedown = e => {
 	if (e.which !== 1) return; // Only work on left mouse button
 	const onSticker = e.target.classList.contains("sticker");
-	if (onSticker && !sticker.current) {
+
+	if (onSticker) {
 		// Move clicked sticker
 		sticker.current = e.target;
 		sticker.current.classList.add("dragging");


### PR DESCRIPTION
Task:
- Fix dragging already generated stickers around initially. 

Tested on:
- Chrome