### PR TITLE
Fix opengraph image url

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,33 +1,8 @@
-const fs = require("fs");
-const path = require("path");
-const util = require("util");
-const readFile = util.promisify(fs.readFile);
 const htmlmin = require("html-minifier");
-
-const inputDir = path.resolve(__dirname, "./src");
-
-const webpackAsset = async name => {
-	const manifestData = await readFile(
-		path.resolve(inputDir, "_includes", ".webpack", "manifest.json")
-	);
-	const manifest = JSON.parse(manifestData);
-
-	const assetPath = manifest[name];
-	if (assetPath == null) {
-		throw new Error(
-			`Unknown Webpack asset requested: ${name}. Check .webpack/manifest.json.`
-		);
-	}
-
-	return assetPath;
-};
-
-const webpackAssetContents = async name => {
-	const assetName = await webpackAsset(name);
-	const filePath = path.resolve(__dirname, "_site", assetName);
-
-	return readFile(filePath);
-};
+const {
+	webpackAsset,
+	webpackAssetContents
+} = require("./_tools/webpackHelpers");
 
 module.exports = eleventyConfig => {
 	eleventyConfig.setUseGitIgnore(false);

--- a/_tools/webpackHelpers.js
+++ b/_tools/webpackHelpers.js
@@ -1,0 +1,44 @@
+const path = require("path");
+const fs = require("fs");
+const util = require("util");
+const readFile = util.promisify(fs.readFile);
+
+const inputDir = path.resolve(__dirname, "..", "src");
+
+const webpackAsset = async name => {
+	const manifestData = await readFile(
+		path.resolve(inputDir, "_includes", ".webpack", "manifest.json")
+	);
+	const manifest = JSON.parse(manifestData);
+
+	const assetPath = manifest[name];
+	if (assetPath == null) {
+		throw new Error(
+			`Unknown Webpack asset requested: ${name}. Check .webpack/manifest.json.`
+		);
+	}
+
+	return assetPath;
+};
+
+const webpackAssetUrl = async (baseUrl, name) => {
+	const path = await webpackAsset(name);
+
+	const url = new URL(baseUrl);
+	url.pathname = path;
+
+	return url.toString();
+};
+
+const webpackAssetContents = async name => {
+	const assetName = await webpackAsset(name);
+	const filePath = path.resolve(__dirname, "..", "_site", assetName);
+
+	return readFile(filePath);
+};
+
+module.exports = {
+	webpackAsset,
+	webpackAssetUrl,
+	webpackAssetContents
+};

--- a/src/_data/.eslintrc.js
+++ b/src/_data/.eslintrc.js
@@ -1,0 +1,1 @@
+../../.eslintrc.js

--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -1,4 +1,8 @@
-module.exports = {
+const { webpackAssetUrl } = require("../../_tools/webpackHelpers");
+
+const siteAbsUrl = "https://fraunces.undercase.xyz";
+
+module.exports = async () => ({
 	title: "Fraunces by Undercase Type",
 	description:
 		'Fraunces is a display, "Old Style" soft-serif typeface inspired by the mannerisms of early 20th century typefaces such as Windsor, Souvenir, and the Cooper Series.',
@@ -16,11 +20,11 @@ module.exports = {
 		},
 		{
 			property: "og:image",
-			content: "https://fraunces.undercase.xyz/img/fraunces_site.png"
+			content: await webpackAssetUrl(siteAbsUrl, "img/fraunces_site.png")
 		},
 		{
 			property: "og:url",
-			content: "https://fraunces.undercase.xyz"
+			content: siteAbsUrl
 		},
 		{
 			property: "og:site_name",
@@ -35,4 +39,4 @@ module.exports = {
 			content: "Fraunces by Undercase Type"
 		}
 	]
-};
+});


### PR DESCRIPTION
The image file referenced from the data file has to go through webpack, to resolve the correct file name. This PR extracts the webpack helpers so they can be used from both the templates as well as from data files.