### PR TITLE
Adding font-display to @font-face rule

### DIFF
--- a/src/css/font.css
+++ b/src/css/font.css
@@ -2,6 +2,7 @@
 	font-family: "Fraunces";
 	src: url("../fonts/Fraunces-VF.woff2");
 	font-weight: 100 900;
+	font-display: swap;
 }
 
 @font-face {
@@ -9,6 +10,7 @@
 	src: url("../fonts/FrauncesItalic-VF.woff2");
 	font-weight: 100 900;
 	font-style: italic;
+	font-display: swap;
 }
 
 body {


### PR DESCRIPTION
For a specimen site it would make sense to use `font-display:block`
as there is no point in showing the content in a system font. Using
our own font is the whole point of a specimen site, right? ;-)

But to appease the site speed gods, we put in a `swap` (which goes
straight to the fallback font, and swaps in Fraunces when it has
loaded).

In the end it won't matter to the end-user, as we'll use FFO to
determine when the fonts have loaded, and likely hide the site
content until this has happened. This means that the `font-display`
behaviour is irrelevant as we take showing/hiding content in our
own hands.