### PR TITLE
Add CNAME file to build output, for GitHub Pages

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -14,6 +14,7 @@ module.exports = eleventyConfig => {
 	);
 
 	eleventyConfig.addFilter("json_stringify", JSON.stringify);
+	eleventyConfig.addPassthroughCopy({ "src/public": "." });
 
 	if (process.env.ELEVENTY_ENV === "production") {
 		eleventyConfig.addTransform("htmlmin", (content, outputPath) => {

--- a/src/public/CNAME
+++ b/src/public/CNAME
@@ -1,0 +1,1 @@
+fraunces.undercase.xyz


### PR DESCRIPTION
See https://help.github.com/en/github/working-with-github-pages/troubleshooting-custom-domains-and-github-pages#cname-errors
for details.

Should fix #78.