### PR TITLE
Don't set opsz directly

### DIFF
--- a/src/css/font.css
+++ b/src/css/font.css
@@ -18,7 +18,6 @@ body {
 }
 
 :root {
-	--opsz: 144;
 	--SOFT: 100;
 	--WONK: 1;
 }
@@ -26,6 +25,5 @@ body {
 *,
 *::before,
 *::after {
-	font-variation-settings: "opsz" var(--opsz), "SOFT" var(--SOFT),
-		"WONK" var(--WONK);
+	font-variation-settings: "SOFT" var(--SOFT), "WONK" var(--WONK);
 }

--- a/src/css/marquee-marq.css
+++ b/src/css/marquee-marq.css
@@ -20,6 +20,8 @@
 }
 
 .marquee-marq-content span {
+	font-variation-settings: "opsz" var(--opsz), "SOFT" var(--SOFT),
+		"WONK" var(--WONK);
 	padding: 0 0.25em;
 }
 

--- a/src/css/opsz-demo.css
+++ b/src/css/opsz-demo.css
@@ -1,10 +1,7 @@
 .opsz-demo {
 	--offset: 50%;
 	--width: 864px; /* Line up with prose content */
-
-	/* Simulate .prose */
-	--opsz: 13;
-	--WONK: 1;
+	--WONK: 1; /* Simulate .prose */
 
 	font-weight: 300;
 	font-size: 1.375rem;
@@ -27,6 +24,7 @@
 	padding-left: 1.5rem;
 	padding-right: 1.5rem;
 	width: var(--width);
+	height: 100%;
 }
 
 .opsz-demo h3 {
@@ -62,13 +60,11 @@
 }
 
 .with-opsz {
-	font-optical-sizing: none;
 	background: var(--fraunces-white);
 }
 
 .without-opsz {
-	--opsz: 144;
-
+	font-optical-sizing: none;
 	position: absolute;
 	top: 0;
 	left: 0;
@@ -133,8 +129,6 @@
 }
 
 .opsz-medium-with {
-	--opsz: 72;
-
 	font-size: 2.5rem;
 }
 
@@ -147,8 +141,6 @@
 }
 
 .opsz-large-with {
-	--opsz: 144;
-
 	font-size: 7rem;
 }
 

--- a/src/css/prose.css
+++ b/src/css/prose.css
@@ -1,5 +1,4 @@
 .prose-content {
-	--opsz: 13;
 	--WONK: 1;
 	--SOFT: 100;
 
@@ -12,8 +11,6 @@
 }
 
 .prose-content h2 {
-	--opsz: 36;
-
 	font-weight: 900;
 	font-size: 2.25rem;
 }

--- a/src/css/soft-demo.css
+++ b/src/css/soft-demo.css
@@ -19,7 +19,6 @@
 
 .soft-demo-text {
 	--SOFT: 100;
-	--opsz: 144;
 
 	font-weight: 900;
 	line-height: 1;

--- a/src/css/sticker-hero.css
+++ b/src/css/sticker-hero.css
@@ -13,7 +13,6 @@
 }
 
 .sticker-hero h1 {
-	--opsz: 144;
 	--WONK: 1;
 	--SOFT: 100;
 
@@ -30,7 +29,6 @@
 }
 
 .sticker-hero h2 {
-	--opsz: 144;
 	--WONK: 1;
 
 	font-weight: 300;

--- a/src/css/wonk-demo.css
+++ b/src/css/wonk-demo.css
@@ -20,7 +20,6 @@
 
 .wonk-demo-text {
 	--WONK: 0;
-	--opsz: 144;
 	--SOFT: 50;
 
 	font-weight: 900;


### PR DESCRIPTION
Except in demos specifically made to show different opsz values
than their font size would automatically set (marquee, slider
demo).

Also turning off opsz for the opsz-slider through font-optical-sizing
instead of setting a specific number. Looks good!